### PR TITLE
Improved counting speed by using bytecount instead of memchr

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,8 @@ authors = ["Loïc Grobol <loic.grobol@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-memchr = "2.2.0"
+bytecount = "0.5.1"
+
+[features]
+runtime-dispatch-simd = ["bytecount/runtime-dispatch-simd"]
+generic-simd = ["bytecount/generic-simd"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use memchr;
+use bytecount;
 
 fn main() {
     let args: Vec<String> = std::env::args().collect();
@@ -16,20 +16,16 @@ fn main() {
 fn count_char<R: std::io::BufRead + ?Sized>(r: &mut R, delim: u8) -> Result<usize, std::io::Error> {
     let mut count = 0;
     loop {
-        let (found, used) = {
+        let used = {
             let available = match r.fill_buf() {
                 Ok(n) => n,
                 Err(ref e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
                 Err(e) => return Err(e),
             };
-            match memchr::memchr(delim, available) {
-                Some(i) => (true, i + 1),
-                None => (false, available.len()),
-            }
+            count += bytecount::count(available, delim);
+            available.len()
         };
-        if found {
-            count += 1;
-        }
+       
         r.consume(used);
         if used == 0 {
             return Ok(count);


### PR DESCRIPTION
By changing memchr to bytecount the counting speed increases dramatically. For more information see:

[Code](https://github.com/llogiq/bytecount)
[Discussion about counting lines crazy fast](https://llogiq.github.io/2016/09/24/newline.html)
[Explanation on how the algorithm works](https://llogiq.github.io/2016/09/27/count.html)